### PR TITLE
Add nic fields ips, allowed_ips and gateways for IPv6 networking in zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,20 @@ nics [REQUIRED]
    - interface [REQUIRED]
    - nic_tag [REQUIRED]
    - vlan_id [OPTIONAL] (default: no vlan)
-   - ip [REQUIRED]
+   - ip [OPTIONAL] (either ip or ips is REQUIRED)
+   - ips [OPTIONAL] (either ip or ips is REQUIRED)
+   - allowed_ips [OPTIONAL]
    - netmask [REQUIRED]
    - gateway [OPTIONAL]
+   - gateways [OPTIONAL]
 
-  example:
+  example (IPv4):
   nics:
     - {interface: "net0", nic_tag: "external", vlan_id: "4", ip: "10.0.4.10", netmask: "255.255.255.0", gateway: "10.0.4.1"}
+
+  example (IPv4+IPv6):
+  nics:
+    - {interface: "net0", nic_tag: "external", ips: ["10.0.4.10/24", "fd66:101f:fc60:aa::1/64"], allowed_ips: ["fd66:101f:fc60:aa::1/64"], netmask: "255.255.255.0", gateway: "10.0.4.1"}
 
 filesystems [OPTIONAL]
   The filesystem source must exist on the global zone before it can be shared to the virtual machine. A `zfs create zones/data/somedata` should be ran once before adding a filesystem to a virtual machine.

--- a/templates/provision.json.j2
+++ b/templates/provision.json.j2
@@ -28,11 +28,45 @@
    {% if nic.vlan_id is defined %}
     ,"vlan_id": "{{ nic.vlan_id }}"
    {% endif %}
-   ,"ip": "{{ nic.ip }}"
+   {% if nic.ip is defined %}
+    ,"ip": "{{ nic.ip }}"
+   {% endif %}
+   {% if nic.ips is defined %}
+    , "ips": [
+      {% for i in nic.ips %}
+        {% if loop.first %}
+          "{{ i }}"
+        {% else %}
+          ,"{{ i }}"
+      {% endif %}
+    {% endfor %}
+ ] {% endif %}
+   {% if nic.allowed_ips is defined %}
+    , "allowed_ips": [
+      {% for i in nic.allowed_ips %}
+        {% if loop.first %}
+          "{{ i }}"
+        {% else %}
+          ,"{{ i }}"
+      {% endif %}
+    {% endfor %}
+ ] {% endif %}
    {% if nic.gateway is defined %}
     ,"gateway": "{{ nic.gateway }}"
    {% endif %}
-   ,"netmask": "{{ nic.netmask }}"
+   {% if nic.gateways is defined %}
+    , "gateways": [
+      {% for gw in nic.gateways %}
+        {% if loop.first %}
+          "{{ gw }}"
+        {% else %}
+          ,"{{ gw }}"
+      {% endif %}
+    {% endfor %}
+ ] {% endif %}
+   {% if nic.netmask is defined %}
+    ,"netmask": "{{ nic.netmask }}"
+   {% endif %}
   }
    {% if not loop.last %}
     ,


### PR DESCRIPTION
Add three nic fields to allow setup of IPv6 in SmartOS zones: ips, allowed_ips and gateways. Add IPv6 example.